### PR TITLE
Improve face recognition performance with cached embeddings

### DIFF
--- a/include/functions.py
+++ b/include/functions.py
@@ -2,6 +2,7 @@ import sys
 import requests
 import logging
 from datetime import datetime
+from deepface.commons import distance as dst
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
 
@@ -18,3 +19,16 @@ def resetDB(database, threshold):
             diff = datetime.now() - database[identity]["last_seen"]
             if diff.seconds >= threshold:
                 database[identity]["cnt"] = 0
+
+def calc_distance(src_emb, test_emb, metric="cosine"):
+    """Calculate distance between two embeddings using the given metric."""
+    if metric == "cosine":
+        return dst.findCosineDistance(src_emb, test_emb)
+    if metric == "euclidean":
+        return dst.findEuclideanDistance(src_emb, test_emb)
+    if metric == "euclidean_l2":
+        src_norm = dst.l2_normalize(src_emb)
+        test_norm = dst.l2_normalize(test_emb)
+        return dst.findEuclideanDistance(src_norm, test_norm)
+    raise ValueError(f"Unsupported metric: {metric}")
+


### PR DESCRIPTION
## Summary
- precompute database face embeddings once at startup for faster lookups
- replace DeepFace.find with DeepFace.represent and custom distance checks
- add helper to compute embedding distances using DeepFace metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a19c0751588327992393bf77ed1fe4